### PR TITLE
Removendo uma chave Pix existente

### DIFF
--- a/src/main/kotlin/br/com/zup/ggwadera/pix/PixKey.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/pix/PixKey.kt
@@ -6,6 +6,12 @@ import javax.validation.constraints.NotBlank
 import javax.validation.constraints.NotNull
 
 @Entity
+@Table(
+    indexes = [
+        Index(name = "idx_uuid", columnList = "uuid", unique = true),
+        Index(name = "idx_uuid_clientId", columnList = "uuid, clientId")
+    ]
+)
 class PixKey(
     @field:NotNull
     @Column(nullable = false)

--- a/src/main/kotlin/br/com/zup/ggwadera/pix/PixKeyRepository.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/pix/PixKeyRepository.kt
@@ -7,5 +7,5 @@ import java.util.*
 @Repository
 interface PixKeyRepository: JpaRepository<PixKey, Long> {
     fun existsByKey(key: String): Boolean
-    fun findByUuid(uuid: UUID): PixKey?
+    fun findByUuidAndClientId(uuid: UUID, clientId: UUID): PixKey?
 }

--- a/src/main/kotlin/br/com/zup/ggwadera/pix/delete/DeletePixKeyEndpoint.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/pix/delete/DeletePixKeyEndpoint.kt
@@ -1,0 +1,21 @@
+package br.com.zup.ggwadera.pix.delete
+
+import br.com.zup.ggwadera.DeleteKeyServiceGrpcKt
+import br.com.zup.ggwadera.DeletePixKeyReply
+import br.com.zup.ggwadera.DeletePixKeyRequest
+import javax.inject.Singleton
+
+@Singleton
+@Suppress("unused")
+class DeletePixKeyEndpoint(private val deletePixKeyService: DeletePixKeyService) :
+    DeleteKeyServiceGrpcKt.DeleteKeyServiceCoroutineImplBase() {
+    override suspend fun deletePixKey(request: DeletePixKeyRequest): DeletePixKeyReply {
+        return with(request) {
+            deletePixKeyService.delete(clientId, pixId)
+            DeletePixKeyReply.newBuilder()
+                .setClientId(clientId)
+                .setPixId(pixId)
+                .build()
+        }
+    }
+}

--- a/src/main/kotlin/br/com/zup/ggwadera/pix/delete/DeletePixKeyService.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/pix/delete/DeletePixKeyService.kt
@@ -1,0 +1,20 @@
+package br.com.zup.ggwadera.pix.delete
+
+import br.com.zup.ggwadera.pix.PixKeyRepository
+import br.com.zup.ggwadera.util.exception.NotFoundException
+import io.micronaut.validation.Validated
+import java.util.*
+import javax.inject.Singleton
+import javax.validation.constraints.NotBlank
+
+@Singleton
+@Validated
+class DeletePixKeyService(private val pixKeyRepository: PixKeyRepository) {
+    fun delete(@NotBlank clientId: String, @NotBlank pixId: String) {
+        val pixKey = pixKeyRepository.findByUuidAndClientId(
+            uuid = UUID.fromString(pixId),
+            clientId = UUID.fromString(clientId)
+        ) ?: throw NotFoundException("chave não existe ou não pertence ao usuário")
+        pixKeyRepository.delete(pixKey)
+    }
+}

--- a/src/main/kotlin/br/com/zup/ggwadera/util/exception/NotFoundException.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/util/exception/NotFoundException.kt
@@ -1,0 +1,3 @@
+package br.com.zup.ggwadera.util.exception
+
+class NotFoundException(message: String?) : RuntimeException(message)

--- a/src/main/kotlin/br/com/zup/ggwadera/util/grpc/ExceptionTranslationServerInterceptor.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/util/grpc/ExceptionTranslationServerInterceptor.kt
@@ -1,6 +1,7 @@
 package br.com.zup.ggwadera.util.grpc
 
 import br.com.zup.ggwadera.util.exception.AlreadyExistsException
+import br.com.zup.ggwadera.util.exception.NotFoundException
 import io.grpc.*
 import io.micronaut.http.client.exceptions.HttpClientResponseException
 import javax.inject.Singleton
@@ -24,6 +25,7 @@ class ExceptionTranslationServerInterceptor : ServerInterceptor {
                 is AlreadyExistsException -> Status.ALREADY_EXISTS
                 is HttpClientResponseException -> Status.INTERNAL
                 is ConstraintViolationException -> Status.INVALID_ARGUMENT
+                is NotFoundException -> Status.NOT_FOUND
                 else -> Status.UNKNOWN
             }.withDescription(cause?.message).withCause(cause)
             return super.close(translatedStatus, trailers)

--- a/src/main/proto/pixKey.proto
+++ b/src/main/proto/pixKey.proto
@@ -11,6 +11,10 @@ service PixService {
   rpc AddPixKey (NewPixKeyRequest) returns (NewPixKeyReply) {}
 }
 
+service DeleteKeyService {
+  rpc DeletePixKey (DeletePixKeyRequest) returns (DeletePixKeyReply) {};
+}
+
 enum KeyType {
   KEY_TYPE_UNSPECIFIED = 0;
   CPF = 1;
@@ -34,4 +38,14 @@ message NewPixKeyRequest {
 
 message NewPixKeyReply {
   string pix_id = 1;
+}
+
+message DeletePixKeyRequest {
+  string client_id = 1;
+  string pix_id = 2;
+}
+
+message DeletePixKeyReply {
+  string client_id = 1;
+  string pix_id = 2;
 }

--- a/src/test/kotlin/br/com/zup/ggwadera/pix/newkey/RegisterKeyEndpointTest.kt
+++ b/src/test/kotlin/br/com/zup/ggwadera/pix/newkey/RegisterKeyEndpointTest.kt
@@ -76,7 +76,7 @@ internal class NewPixKeyEndpointTest {
 
         val response = grpcClient.addPixKey(request)
         assertFalse(response.pixId.isNullOrBlank())
-        val created = pixKeyRepository.findByUuid(UUID.fromString(response.pixId))
+        val created = pixKeyRepository.findByUuidAndClientId(UUID.fromString(response.pixId), clientId)
         assertNotNull(created)
         with(created!!) {
             assertEquals(clientId, this.clientId)


### PR DESCRIPTION
## Necessidades

Nosso usuário precisa excluir suas chaves Pix cadastradas, pois dessa forma, se necessário, ele poderá recriar uma chave associada à uma nova conta corrente ou poupança.

## Restrições

Para excluir uma chave Pix, precisamos que o usuário informe os seguintes dados:

- **Pix ID** (idenficiador interno da chave Pix) deve ser obrigatório;

- **Identificador do cliente** deve ser obrigatório:
   - Código interno do cliente na Instituição Financeira existente no [Sistema ERP do Itaú](http://localhost:9091/api/v1/private/contas/todas);

A chave pode ser removida somente pelo seu dono (cliente).

## Resultado Esperado

- Em caso de sucesso, a chave Pix deve ser excluída do sistema;

- Em caso de chave não encontrada, deve-se retornar status de erro `NOT_FOUND` com uma mensagem amigável para o usuário final;

- Em caso de erro, deve-se retornar o erro específico e amigável para o usuário final;