### PR TITLE
Testando a Remoção de chave Pix existente

### DIFF
--- a/src/test/kotlin/br/com/zup/ggwadera/pix/delete/DeletePixKeyEndpointTest.kt
+++ b/src/test/kotlin/br/com/zup/ggwadera/pix/delete/DeletePixKeyEndpointTest.kt
@@ -28,22 +28,18 @@ internal class DeletePixKeyEndpointTest(
     private val grpcClient: DeleteKeyServiceGrpc.DeleteKeyServiceBlockingStub
 ) {
 
-    companion object {
-        private val clientId: UUID = UUID.randomUUID()
-        private const val key = "test@email.com"
-    }
-
-    private var pixKey: PixKey = PixKey(clientId, key, KeyType.EMAIL, AccountType.CONTA_CORRENTE)
+    private lateinit var pixKey: PixKey
 
     @BeforeEach
     internal fun setUp() {
-        val entity = PixKey(
-            clientId = clientId,
-            key = key,
-            keyType = KeyType.EMAIL,
-            accountType = AccountType.CONTA_CORRENTE
+        pixKey = pixKeyRepository.save(
+            PixKey(
+                clientId = UUID.randomUUID(),
+                key = "test@email.com",
+                keyType = KeyType.EMAIL,
+                accountType = AccountType.CONTA_CORRENTE
+            )
         )
-        pixKey = pixKeyRepository.save(entity)
     }
 
     @AfterEach
@@ -62,14 +58,14 @@ internal class DeletePixKeyEndpointTest(
     @Test
     internal fun `deve remover chave com sucesso`() {
         val request = DeletePixKeyRequest.newBuilder()
-            .setClientId(clientId.toString())
+            .setClientId(pixKey.clientId.toString())
             .setPixId(pixKey.uuid.toString())
             .build()
 
         val response = grpcClient.deletePixKey(request)
 
         with(response) {
-            assertEquals(clientId.toString(), this.clientId)
+            assertEquals(pixKey.clientId.toString(), this.clientId)
             assertEquals(pixKey.uuid.toString(), this.pixId)
         }
         assertFalse(pixKeyRepository.existsById(pixKey.id))
@@ -78,7 +74,7 @@ internal class DeletePixKeyEndpointTest(
     @Test
     internal fun `deve retornar NOT_FOUND caso chave nao exista`() {
         val request = DeletePixKeyRequest.newBuilder()
-            .setClientId(clientId.toString())
+            .setClientId(pixKey.clientId.toString())
             .setPixId(UUID.randomUUID().toString())
             .build()
 

--- a/src/test/kotlin/br/com/zup/ggwadera/pix/delete/DeletePixKeyEndpointTest.kt
+++ b/src/test/kotlin/br/com/zup/ggwadera/pix/delete/DeletePixKeyEndpointTest.kt
@@ -1,0 +1,117 @@
+package br.com.zup.ggwadera.pix.delete
+
+import br.com.zup.ggwadera.DeleteKeyServiceGrpc
+import br.com.zup.ggwadera.DeletePixKeyRequest
+import br.com.zup.ggwadera.pix.AccountType
+import br.com.zup.ggwadera.pix.KeyType
+import br.com.zup.ggwadera.pix.PixKey
+import br.com.zup.ggwadera.pix.PixKeyRepository
+import io.grpc.ManagedChannel
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import io.micronaut.context.annotation.Factory
+import io.micronaut.grpc.annotation.GrpcChannel
+import io.micronaut.grpc.server.GrpcServerChannel
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.util.*
+import javax.inject.Singleton
+
+@MicronautTest(transactional = false)
+internal class DeletePixKeyEndpointTest(
+    private val pixKeyRepository: PixKeyRepository,
+    private val grpcClient: DeleteKeyServiceGrpc.DeleteKeyServiceBlockingStub
+) {
+
+    companion object {
+        private val clientId: UUID = UUID.randomUUID()
+        private const val key = "test@email.com"
+    }
+
+    private var pixKey: PixKey = PixKey(clientId, key, KeyType.EMAIL, AccountType.CONTA_CORRENTE)
+
+    @BeforeEach
+    internal fun setUp() {
+        val entity = PixKey(
+            clientId = clientId,
+            key = key,
+            keyType = KeyType.EMAIL,
+            accountType = AccountType.CONTA_CORRENTE
+        )
+        pixKey = pixKeyRepository.save(entity)
+    }
+
+    @AfterEach
+    internal fun tearDown() {
+        pixKeyRepository.deleteAll()
+    }
+
+    @Factory
+    class Client {
+        @Singleton
+        fun blockingStub(@GrpcChannel(GrpcServerChannel.NAME) channel: ManagedChannel): DeleteKeyServiceGrpc.DeleteKeyServiceBlockingStub {
+            return DeleteKeyServiceGrpc.newBlockingStub(channel)
+        }
+    }
+
+    @Test
+    internal fun `deve remover chave com sucesso`() {
+        val request = DeletePixKeyRequest.newBuilder()
+            .setClientId(clientId.toString())
+            .setPixId(pixKey.uuid.toString())
+            .build()
+
+        val response = grpcClient.deletePixKey(request)
+
+        with(response) {
+            assertEquals(clientId.toString(), this.clientId)
+            assertEquals(pixKey.uuid.toString(), this.pixId)
+        }
+        assertFalse(pixKeyRepository.existsById(pixKey.id))
+    }
+
+    @Test
+    internal fun `deve retornar NOT_FOUND caso chave nao exista`() {
+        val request = DeletePixKeyRequest.newBuilder()
+            .setClientId(clientId.toString())
+            .setPixId(UUID.randomUUID().toString())
+            .build()
+
+        val response = assertThrows<StatusRuntimeException> { grpcClient.deletePixKey(request) }
+        with(response.status) {
+            assertEquals(Status.NOT_FOUND.code, code)
+            assertEquals("chave não existe ou não pertence ao usuário", description)
+        }
+    }
+
+    @Test
+    internal fun `deve retornar NOT_FOUND caso chave nao pertenca ao cliente`() {
+        val request = DeletePixKeyRequest.newBuilder()
+            .setClientId(UUID.randomUUID().toString())
+            .setPixId(pixKey.uuid.toString())
+            .build()
+
+        val response = assertThrows<StatusRuntimeException> { grpcClient.deletePixKey(request) }
+        with(response.status) {
+            assertEquals(Status.NOT_FOUND.code, code)
+            assertEquals("chave não existe ou não pertence ao usuário", description)
+        }
+    }
+
+
+
+    @Test
+    internal fun `deve retornar INVALID_ARGUMENT caso parametro esteja em branco`() {
+        val request = DeletePixKeyRequest.newBuilder().build()
+
+        val response = assertThrows<StatusRuntimeException> { grpcClient.deletePixKey(request) }
+        with(response.status) {
+            assertEquals(Status.INVALID_ARGUMENT.code, code)
+        }
+    }
+}


### PR DESCRIPTION
## Necessidades

Nós finalizamos a implementação do endpoint responsável por [remover uma chave Pix existente](https://github.com/zup-academy/orange-stack-documentacao/blob/master/desafio-01/01-key-manager/010-removendo-uma-chave-pix-existente.md), mas precisamos cobrí-la com testes automatizados antes de colocá-la em produção. 

A idéia de escrever testes é **encontrar bugs** antes de ir para produção. Quanto mais cedo encontrarmos um bug mais barato é sua resolução. Por esse motivo, precisamos encontrar bugs antes de deployar a aplicação em ambiente de produção (ou mesmo homologação).

Então, vamos cobrir com testes esse endpoint?

## Restrições

Escrever testes automatizados para o endpoint gRPC de Remoção de chave Pix implementado de tal forma que os testes garantam o que foi especificado na atividade.

Para guia-lo(a) nessa atividade, elencamos algumas restrições e pontos de atenção:

- favoreça a escrita de **testes de unidade** para lógicas de negócio que não fazem integração com serviços externos (banco de dados, APIs REST, mensageria, sistema de arquivos etc);
- favoreça a escrita de **testes de integração** para lógicas de negócio que conversam com serviços externos, como banco de dados, APIs REST etc;
- para tornar o teste mais próximo da produção, nos testes de integração **levante um servidor gRPC embarcado** e consuma os endpoints nos testes de integração;
- lembre-se de **testar os fluxos alternativos**, como cenários de erros do sistema ou entrada de dados inválida pelo usuário/serviço;
- favoreça o uso de um **banco de dados em memória** para facilitar a limpeza dos dados e simplificar o ambiente na sua pipeline de CI/CD;
- favoreça **mocks para chamadas à serviços externos**, como a API REST do Sistema ERP-ITAU e do Sistema Pix do BCB;
- fique sempre de olho na **cobertura do seu código**, especialmente nas branches de código, como `if`, `else`, `while`, `for`, `try-catch` etc;

Quer entender por que adotamos as restrições acima? [Assiste a esse vídeo](https://www.youtube.com/watch?v=IMvjNpG6320) para entender os detalhes do porquê acreditamos que esse é um bom caminho.

## Resultado Esperado

O que esperamos ao final dessa atividade e que também consideramos importante:

- ter um percentual de cobertura de no mínimo **90% do código de produção**;
- ter coberto cenários felizes (happy-path) e fluxos alternativos;
- não precisar de instruções especiais para preparar o ambiente ou para rodar sua bateria de testes;
- sua bateria de testes deve rodar tanto na sua IDE quanto via **linha de comando**;
- que outro desenvolvedor(a) do time consiga rodar facilmente a bateria de testes do seu serviço;