### PR TITLE
Registrando e excluindo chaves Pix no Banco Central (BCB)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -55,6 +55,7 @@ dependencies {
     runtimeOnly("com.fasterxml.jackson.module:jackson-module-kotlin")
 
     testImplementation("org.mockito:mockito-core")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:3.2.0")
     testImplementation("org.junit.jupiter:junit-jupiter-api")
     testImplementation("org.junit.jupiter:junit-jupiter-params")
     testImplementation("io.micronaut.test:micronaut-test-junit5")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation("io.micronaut.beanvalidation:micronaut-hibernate-validator")
     implementation("org.hibernate:hibernate-validator:6.1.6.Final")
     implementation("io.micronaut:micronaut-http-client")
+    implementation("io.micronaut.xml:micronaut-jackson-xml")
 
     annotationProcessor("io.micronaut:micronaut-validation")
 

--- a/src/main/kotlin/br/com/zup/ggwadera/bcb/BcbClient.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/bcb/BcbClient.kt
@@ -1,0 +1,121 @@
+package br.com.zup.ggwadera.bcb
+
+import br.com.zup.ggwadera.itau.AccountResponse
+import br.com.zup.ggwadera.pix.Account
+import br.com.zup.ggwadera.pix.KeyType
+import br.com.zup.ggwadera.pix.PixKey
+import br.com.zup.ggwadera.pix.register.NewPixKey
+import io.micronaut.http.MediaType.APPLICATION_XML
+import io.micronaut.http.annotation.*
+import io.micronaut.http.client.annotation.Client
+import java.time.LocalDateTime
+import java.util.*
+import br.com.zup.ggwadera.pix.AccountType as PixAccountType
+import br.com.zup.ggwadera.pix.Owner as PixOwner
+
+@Client("\${services.bcb}")
+@Consumes(APPLICATION_XML)
+@Produces(APPLICATION_XML)
+interface BcbClient {
+
+    @Post("/api/v1/pix/keys")
+    fun registerKey(@Body body: CreatePixKeyRequest): CreatePixKeyResponse?
+
+    @Delete("/api/v1/pix/keys/{key}")
+    fun deleteKey(@PathVariable key: String, @Body body: DeletePixKeyRequest): DeletePixKeyResponse?
+
+}
+
+data class CreatePixKeyRequest(
+    val key: String,
+    val keyType: KeyType,
+    val bankAccount: BankAccount,
+    val owner: Owner
+) {
+    constructor(pixKey: NewPixKey, account: AccountResponse) : this(
+        key = pixKey.key,
+        keyType = pixKey.keyType!!,
+        bankAccount = BankAccount(account.toModel()),
+        owner = Owner(account.titular.toModel())
+    )
+}
+
+data class CreatePixKeyResponse(
+    val key: String,
+    val keyType: KeyType,
+    val createdAt: LocalDateTime,
+    val bankAccount: BankAccount,
+    val owner: Owner
+) {
+    fun toModel(clientId: UUID): PixKey = PixKey(
+        key = key,
+        keyType = keyType,
+        account = bankAccount.toModel(),
+        owner = owner.toModel(clientId),
+        createdAt = createdAt
+    )
+}
+
+data class DeletePixKeyRequest(
+    val key: String,
+    val participant: String
+)
+
+data class DeletePixKeyResponse(
+    val key: String,
+    val participant: String,
+    val deletedAt: LocalDateTime
+)
+
+data class BankAccount(
+    val participant: String,
+    val branch: String,
+    val accountNumber: String,
+    val accountType: AccountType
+) {
+    fun toModel(): Account = Account(
+        participant = participant,
+        branch = branch,
+        number = accountNumber,
+        type = accountType.mapping
+    )
+
+    constructor(account: Account) : this(
+        Account.ISPB_ITAU_UNIBANCO,
+        account.branch,
+        account.number,
+        AccountType.of(account.type)
+    )
+
+    enum class AccountType(val mapping: PixAccountType) {
+        CACC(PixAccountType.CONTA_CORRENTE),
+        SVGS(PixAccountType.CONTA_POUPANCA);
+
+        companion object {
+            fun of(accountType: PixAccountType): AccountType =
+                when (accountType) {
+                    PixAccountType.CONTA_CORRENTE -> CACC
+                    PixAccountType.CONTA_POUPANCA -> SVGS
+                }
+        }
+    }
+}
+
+data class Owner(
+    val type: OwnerType,
+    val name: String,
+    val taxIdNumber: String
+) {
+    fun toModel(clientId: UUID): PixOwner = PixOwner(
+        id = clientId,
+        name = name,
+        taxIdNumber = taxIdNumber
+    )
+
+    constructor(owner: PixOwner) : this(OwnerType.NATURAL_PERSON, owner.name, owner.taxIdNumber)
+
+    enum class OwnerType {
+        NATURAL_PERSON,
+        LEGAL_PERSON
+    }
+}

--- a/src/main/kotlin/br/com/zup/ggwadera/itau/ItauClient.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/itau/ItauClient.kt
@@ -1,14 +1,52 @@
 package br.com.zup.ggwadera.itau
 
+import br.com.zup.ggwadera.pix.Account
+import br.com.zup.ggwadera.pix.AccountType
+import br.com.zup.ggwadera.pix.Owner
 import io.micronaut.http.annotation.Get
 import io.micronaut.http.annotation.PathVariable
+import io.micronaut.http.annotation.QueryValue
 import io.micronaut.http.client.annotation.Client
 import java.util.*
-import javax.validation.constraints.NotBlank
 
 @Client("\${services.erp}")
 interface ItauClient {
 
     @Get("/api/v1/clientes/{clienteId}")
     fun getClientInfo(@PathVariable clienteId: UUID): ClientDataResponse?
+
+    @Get("/api/v1/clientes/{clientId}/contas")
+    fun getAccount(@PathVariable clientId: UUID, @QueryValue("tipo") accountType: AccountType): AccountResponse?
+}
+
+data class AccountResponse(
+    val tipo: AccountType,
+    val instituicao: BankResponse,
+    val agencia: String,
+    val numero: String,
+    val titular: OwnerResponse
+) {
+    data class BankResponse(
+        val nome: String,
+        val ispb: String
+    )
+
+    data class OwnerResponse(
+        val id: UUID,
+        val nome: String,
+        val cpf: String
+    ) {
+        fun toModel(): Owner = Owner(
+            id = id,
+            name = nome,
+            taxIdNumber = cpf
+        )
+    }
+
+    fun toModel(): Account = Account(
+        participant = instituicao.ispb,
+        branch = agencia,
+        number = numero,
+        type = tipo
+    )
 }

--- a/src/main/kotlin/br/com/zup/ggwadera/pix/Account.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/pix/Account.kt
@@ -1,0 +1,26 @@
+package br.com.zup.ggwadera.pix
+
+import javax.persistence.Column
+import javax.persistence.Embeddable
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+
+@Embeddable
+data class Account(
+    @Column(name = "account_participant", nullable = false)
+    val participant: String,
+
+    @Column(name = "account_branch", nullable = false, length = 4)
+    val branch: String,
+
+    @Column(name = "account_number", nullable = false, length = 6)
+    val number: String,
+
+    @Column(name = "account_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    val type: AccountType
+) {
+    companion object {
+        const val ISPB_ITAU_UNIBANCO: String = "60701190"
+    }
+}

--- a/src/main/kotlin/br/com/zup/ggwadera/pix/Owner.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/pix/Owner.kt
@@ -1,0 +1,17 @@
+package br.com.zup.ggwadera.pix
+
+import java.util.*
+import javax.persistence.Column
+import javax.persistence.Embeddable
+
+@Embeddable
+data class Owner (
+    @Column(name = "owner_id", nullable = false)
+    val id: UUID,
+
+    @Column(name = "owner_name", nullable = false)
+    val name: String,
+
+    @Column(name = "owner_tax_id", nullable = false, length = 11, updatable = false)
+    val taxIdNumber: String
+)

--- a/src/main/kotlin/br/com/zup/ggwadera/pix/PixKey.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/pix/PixKey.kt
@@ -1,40 +1,39 @@
 package br.com.zup.ggwadera.pix
 
+import java.time.LocalDateTime
 import java.util.*
 import javax.persistence.*
 import javax.validation.constraints.NotBlank
-import javax.validation.constraints.NotNull
 
 @Entity
 @Table(
     indexes = [
         Index(name = "idx_uuid", columnList = "uuid", unique = true),
-        Index(name = "idx_uuid_clientId", columnList = "uuid, clientId")
+        Index(name = "idx_uuid_ownerId", columnList = "uuid, owner_id")
     ]
 )
 class PixKey(
-    @field:NotNull
-    @Column(nullable = false)
-    val clientId: UUID,
-
     @field:NotBlank
     @Column(nullable = false)
     val key: String,
 
-    @field:NotNull
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     val keyType: KeyType,
 
-    @field:NotNull
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    val accountType: AccountType
+    @Embedded
+    val account: Account,
+
+    @Embedded
+    val owner: Owner,
+
+    @Column(nullable = false, updatable = false)
+    val createdAt: LocalDateTime
 ) {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0
 
-    @Column(nullable = false)
+    @Column(nullable = false, updatable = false)
     val uuid: UUID = UUID.randomUUID()
 }

--- a/src/main/kotlin/br/com/zup/ggwadera/pix/PixKeyRepository.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/pix/PixKeyRepository.kt
@@ -7,5 +7,5 @@ import java.util.*
 @Repository
 interface PixKeyRepository: JpaRepository<PixKey, Long> {
     fun existsByKey(key: String): Boolean
-    fun findByUuidAndClientId(uuid: UUID, clientId: UUID): PixKey?
+    fun findByUuidAndOwnerId(uuid: UUID, ownerId: UUID): PixKey?
 }

--- a/src/main/kotlin/br/com/zup/ggwadera/pix/delete/DeletePixKeyService.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/pix/delete/DeletePixKeyService.kt
@@ -1,5 +1,8 @@
 package br.com.zup.ggwadera.pix.delete
 
+import br.com.zup.ggwadera.bcb.BcbClient
+import br.com.zup.ggwadera.bcb.DeletePixKeyRequest
+import br.com.zup.ggwadera.pix.PixKey
 import br.com.zup.ggwadera.pix.PixKeyRepository
 import br.com.zup.ggwadera.util.exception.NotFoundException
 import io.micronaut.validation.Validated
@@ -9,12 +12,23 @@ import javax.validation.constraints.NotBlank
 
 @Singleton
 @Validated
-class DeletePixKeyService(private val pixKeyRepository: PixKeyRepository) {
+class DeletePixKeyService(
+    private val pixKeyRepository: PixKeyRepository,
+    private val bcbClient: BcbClient
+) {
     fun delete(@NotBlank clientId: String, @NotBlank pixId: String) {
-        val pixKey = pixKeyRepository.findByUuidAndClientId(
-            uuid = UUID.fromString(pixId),
-            clientId = UUID.fromString(clientId)
-        ) ?: throw NotFoundException("chave não existe ou não pertence ao usuário")
+        val pixKey = findKey(pixId, clientId)
+        sendKeyDeleteRequest(pixKey)
         pixKeyRepository.delete(pixKey)
+    }
+
+    private fun findKey(pixId: String, clientId: String) = pixKeyRepository.findByUuidAndOwnerId(
+        uuid = UUID.fromString(pixId),
+        ownerId = UUID.fromString(clientId)
+    ) ?: throw NotFoundException("chave não existe ou não pertence ao usuário")
+
+    private fun sendKeyDeleteRequest(pixKey: PixKey) = with(pixKey) {
+        bcbClient.deleteKey(key, DeletePixKeyRequest(key, account.participant))
+            ?: throw IllegalStateException("Falha ao apagar registro no Banco Central")
     }
 }

--- a/src/main/kotlin/br/com/zup/ggwadera/pix/register/NewPixKey.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/pix/register/NewPixKey.kt
@@ -2,8 +2,6 @@ package br.com.zup.ggwadera.pix.register
 
 import br.com.zup.ggwadera.pix.AccountType
 import br.com.zup.ggwadera.pix.KeyType
-import br.com.zup.ggwadera.pix.KeyType.RANDOM
-import br.com.zup.ggwadera.pix.PixKey
 import io.micronaut.core.annotation.Introspected
 import java.util.*
 import javax.validation.constraints.NotNull
@@ -12,10 +10,8 @@ import javax.validation.constraints.Size
 @Introspected
 @ValidPixKey
 data class NewPixKey(
-    @field:NotNull
     val clientId: UUID,
 
-    @field:NotNull
     @field:Size(max = 77)
     val key: String,
 
@@ -24,11 +20,4 @@ data class NewPixKey(
 
     @field:NotNull
     val accountType: AccountType?
-) {
-    fun toModel() = PixKey(
-        clientId = clientId,
-        key = if (keyType == RANDOM) UUID.randomUUID().toString() else key,
-        keyType = keyType!!,
-        accountType = accountType!!
-    )
-}
+)

--- a/src/main/kotlin/br/com/zup/ggwadera/pix/register/RegisterKeyService.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/pix/register/RegisterKeyService.kt
@@ -38,7 +38,7 @@ class RegisterKeyService(
         account: AccountResponse
     ): CreatePixKeyResponse {
         return bcbClient.registerKey(CreatePixKeyRequest(newPixKey, account))
-            ?: throw IllegalStateException("Falha ao registrar chave no Banco Central" )
+            ?: throw IllegalStateException("Falha ao registrar chave no Banco Central")
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,3 +22,4 @@ jpa:
 
 services:
   erp: 'http://localhost:9091'
+  bcb: 'http://localhost:8082'

--- a/src/test/kotlin/br/com/zup/ggwadera/pix/delete/DeletePixKeyEndpointTest.kt
+++ b/src/test/kotlin/br/com/zup/ggwadera/pix/delete/DeletePixKeyEndpointTest.kt
@@ -2,25 +2,28 @@ package br.com.zup.ggwadera.pix.delete
 
 import br.com.zup.ggwadera.DeleteKeyServiceGrpc
 import br.com.zup.ggwadera.DeletePixKeyRequest
-import br.com.zup.ggwadera.pix.AccountType
-import br.com.zup.ggwadera.pix.KeyType
-import br.com.zup.ggwadera.pix.PixKey
-import br.com.zup.ggwadera.pix.PixKeyRepository
+import br.com.zup.ggwadera.bcb.BcbClient
+import br.com.zup.ggwadera.bcb.DeletePixKeyResponse
+import br.com.zup.ggwadera.pix.*
 import io.grpc.ManagedChannel
 import io.grpc.Status
 import io.grpc.StatusRuntimeException
 import io.micronaut.context.annotation.Factory
 import io.micronaut.grpc.annotation.GrpcChannel
 import io.micronaut.grpc.server.GrpcServerChannel
+import io.micronaut.test.annotation.MockBean
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.mockito.kotlin.*
+import java.time.LocalDateTime
 import java.util.*
+import javax.inject.Inject
 import javax.inject.Singleton
+import br.com.zup.ggwadera.bcb.DeletePixKeyRequest as BcbDeletePixKeyRequest
 
 @MicronautTest(transactional = false)
 internal class DeletePixKeyEndpointTest(
@@ -28,16 +31,40 @@ internal class DeletePixKeyEndpointTest(
     private val grpcClient: DeleteKeyServiceGrpc.DeleteKeyServiceBlockingStub
 ) {
 
+    @Inject
+    private lateinit var bcbClient: BcbClient
+
     private lateinit var pixKey: PixKey
+
+    @MockBean(BcbClient::class)
+    fun mockBcbClient() = mock<BcbClient>() {
+        on { deleteKey(any(), any()) } doAnswer { mockInvocation ->
+            DeletePixKeyResponse(
+                mockInvocation.arguments[0] as String,
+                Account.ISPB_ITAU_UNIBANCO,
+                LocalDateTime.now()
+            )
+        }
+    }
 
     @BeforeEach
     internal fun setUp() {
         pixKey = pixKeyRepository.save(
             PixKey(
-                clientId = UUID.randomUUID(),
                 key = "test@email.com",
                 keyType = KeyType.EMAIL,
-                accountType = AccountType.CONTA_CORRENTE
+                account = Account(
+                    participant = Account.ISPB_ITAU_UNIBANCO,
+                    branch = "0123",
+                    number = "012345",
+                    type = AccountType.CONTA_CORRENTE
+                ),
+                owner = Owner(
+                    id = UUID.randomUUID(),
+                    name = "Bill Gates",
+                    taxIdNumber = "12345678901"
+                ),
+                createdAt = LocalDateTime.now()
             )
         )
     }
@@ -58,23 +85,24 @@ internal class DeletePixKeyEndpointTest(
     @Test
     internal fun `deve remover chave com sucesso`() {
         val request = DeletePixKeyRequest.newBuilder()
-            .setClientId(pixKey.clientId.toString())
+            .setClientId(pixKey.owner.id.toString())
             .setPixId(pixKey.uuid.toString())
             .build()
 
         val response = grpcClient.deletePixKey(request)
 
         with(response) {
-            assertEquals(pixKey.clientId.toString(), this.clientId)
+            assertEquals(pixKey.owner.id.toString(), this.clientId)
             assertEquals(pixKey.uuid.toString(), this.pixId)
         }
         assertFalse(pixKeyRepository.existsById(pixKey.id))
+        verify(bcbClient).deleteKey(pixKey.key, BcbDeletePixKeyRequest(pixKey.key, pixKey.account.participant))
     }
 
     @Test
     internal fun `deve retornar NOT_FOUND caso chave nao exista`() {
         val request = DeletePixKeyRequest.newBuilder()
-            .setClientId(pixKey.clientId.toString())
+            .setClientId(pixKey.owner.id.toString())
             .setPixId(UUID.randomUUID().toString())
             .build()
 
@@ -83,6 +111,7 @@ internal class DeletePixKeyEndpointTest(
             assertEquals(Status.NOT_FOUND.code, code)
             assertEquals("chave não existe ou não pertence ao usuário", description)
         }
+        verify(bcbClient, never()).deleteKey(any(), any())
     }
 
     @Test
@@ -97,8 +126,8 @@ internal class DeletePixKeyEndpointTest(
             assertEquals(Status.NOT_FOUND.code, code)
             assertEquals("chave não existe ou não pertence ao usuário", description)
         }
+        verify(bcbClient, never()).deleteKey(any(), any())
     }
-
 
 
     @Test
@@ -109,5 +138,29 @@ internal class DeletePixKeyEndpointTest(
         with(response.status) {
             assertEquals(Status.INVALID_ARGUMENT.code, code)
         }
+        verify(bcbClient, never()).deleteKey(any(), any())
+    }
+
+    @Test
+    internal fun `deve retornar erro FAILED_PRECONDITION caso falhe ao deletar chave no BCB`() {
+        val request = DeletePixKeyRequest.newBuilder()
+            .setClientId(pixKey.owner.id.toString())
+            .setPixId(pixKey.uuid.toString())
+            .build()
+
+        whenever(
+            bcbClient.deleteKey(
+                pixKey.key,
+                BcbDeletePixKeyRequest(pixKey.key, pixKey.account.participant)
+            )
+        ).thenReturn(null)
+
+        val response = assertThrows<StatusRuntimeException> { grpcClient.deletePixKey(request) }
+        with(response.status) {
+            assertEquals(Status.FAILED_PRECONDITION.code, code)
+            assertEquals("Falha ao apagar registro no Banco Central", description)
+        }
+        // chave não deveria ter sido deletada
+        assertTrue(pixKeyRepository.existsById(pixKey.id))
     }
 }


### PR DESCRIPTION
## Necessidades

Não basta registrar as chaves Pix no nosso sistema, elas precisam ser **registradas no Banco Central (BCB)**, caso contrário elas não poderão ser compartilhadas por nossos usuários nem utilizadas abertamente por diversas pessoas e instituições financeiras, como bancos, fintechs e meios de pagemento.

Por esse motivo, sempre que registrarmos uma chave Pix no nosso sistema ela também deve ser registrada globalmente, ou seja, no **Sistema Pix do BCB**. Não só isso, caso uma chave seja excluída do nosso sistema ela também deverá ser excluída no BCB.

## Restrições

Para registrar ou excluir uma chave Pix globalmente, precisamos nos integrar ao Sistema Pix do BCB por meio de uma API REST disponibilizada por eles. Para acessar a API e analisá-la, basta acessar o link abaixo:

[http://localhost:8082/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config#/](http://localhost:8082/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config#/)

Lembre-se, nosso sistema precisa manter um "link" entre a chave cadastrada no nosso sistema e a chave registrada no Sistema Pix do BCB, caso contrário não poderemos compartilhá-la nem excluí-la futuramente. Ou seja, uma chave desconhecida pelo BCB é uma chave inválida para qualquer fim.

O BCB será o sistema responsável por gerar a chave do tipo `ALEATORIA` em vez do nosso sistema. Portanto, nesse caso, o BCB ignorará qualquer chave enviada pelo nosso sistema.

Um detalhe importante, toda chave Pix registrada no BCB pelo nosso serviço deve usar o ISPB (Identificador de Sistema de Pagamento Brasileiro) do ITAÚ UNIBANCO S.A cujo valor é `60701190`.

## Resultado Esperado

- Ao cadastrar uma chave no nosso sistema, deve-se garantir que ela esteja devidamente registrada no Sistema Pix do BCB;

- Ao excluir uma chave existente no nosso sistema, deve-se garantir que ela tenha sido excluída primeiramente do Sistema Pix do BCB;

- Ao registrar uma chave do tipo `ALEATORIA` no BCB, deve-se também atualizar a chave no nosso sistema com a chave gerada pelo BCB;

- Uma chave Pix no nosso sistema somente poderá ser disponibilizada para uso dos nossos usuários (compartilhamento, geração de cobranças, pagamentos etc) quando ela estiver devidamente registrada e linkada à uma chave Pix existente no BCB;
