### PR TITLE
Listando todas as chaves Pix do cliente

### DIFF
--- a/src/main/kotlin/br/com/zup/ggwadera/pix/AccountType.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/pix/AccountType.kt
@@ -1,6 +1,10 @@
 package br.com.zup.ggwadera.pix
 
+import br.com.zup.ggwadera.AccountType
+
 enum class AccountType {
     CONTA_CORRENTE,
-    CONTA_POUPANCA
+    CONTA_POUPANCA;
+
+    fun toGrpc() = AccountType.valueOf(this.name)
 }

--- a/src/main/kotlin/br/com/zup/ggwadera/pix/KeyType.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/pix/KeyType.kt
@@ -1,5 +1,6 @@
 package br.com.zup.ggwadera.pix
 
+import br.com.zup.ggwadera.KeyType
 import org.hibernate.validator.internal.constraintvalidators.hv.EmailValidator
 import org.hibernate.validator.internal.constraintvalidators.hv.br.CPFValidator
 
@@ -28,6 +29,8 @@ enum class KeyType {
     };
 
     abstract fun validate(key: String?): Boolean
+
+    fun toGrpc() = KeyType.valueOf(this.name)
 
     companion object {
         private const val CPF_PATTERN = "^[0-9]{11}\$"

--- a/src/main/kotlin/br/com/zup/ggwadera/pix/PixKeyRepository.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/pix/PixKeyRepository.kt
@@ -1,12 +1,14 @@
 package br.com.zup.ggwadera.pix
 
+import br.com.zup.ggwadera.pix.list.ListKeysItem
 import io.micronaut.data.annotation.Repository
 import io.micronaut.data.jpa.repository.JpaRepository
 import java.util.*
 
 @Repository
-interface PixKeyRepository: JpaRepository<PixKey, Long> {
+interface PixKeyRepository : JpaRepository<PixKey, Long> {
     fun existsByKey(key: String): Boolean
     fun findByUuidAndClientId(uuid: UUID, clientId: UUID): PixKey?
     fun findByKey(key: String): PixKey?
+    fun findByClientId(clientId: UUID): List<ListKeysItem>
 }

--- a/src/main/kotlin/br/com/zup/ggwadera/pix/list/ListKeysEndpoint.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/pix/list/ListKeysEndpoint.kt
@@ -1,0 +1,24 @@
+package br.com.zup.ggwadera.pix.list
+
+import br.com.zup.ggwadera.ListKeysServiceGrpcKt
+import br.com.zup.ggwadera.ListPixKeysReply
+import br.com.zup.ggwadera.ListPixKeysRequest
+import javax.inject.Singleton
+
+@Singleton
+@Suppress("unused")
+class ListKeysEndpoint(
+    private val listKeysService: ListKeysService
+) : ListKeysServiceGrpcKt.ListKeysServiceCoroutineImplBase() {
+
+    override suspend fun listPixKeys(request: ListPixKeysRequest): ListPixKeysReply =
+        listKeysService.findAll(request.clientId)
+            .map { it.toGrpcResponse() }
+            .let { keys ->
+                ListPixKeysReply.newBuilder()
+                    .setClientId(request.clientId)
+                    .addAllKeys(keys)
+                    .build()
+            }
+
+}

--- a/src/main/kotlin/br/com/zup/ggwadera/pix/list/ListKeysItem.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/pix/list/ListKeysItem.kt
@@ -1,0 +1,31 @@
+package br.com.zup.ggwadera.pix.list
+
+import br.com.zup.ggwadera.ListPixKeysReply
+import br.com.zup.ggwadera.pix.Account
+import br.com.zup.ggwadera.pix.KeyType
+import com.google.protobuf.Timestamp
+import io.micronaut.core.annotation.Introspected
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.util.*
+
+@Introspected
+data class ListKeysItem(
+    val uuid: UUID,
+    val clientId: UUID,
+    val keyType: KeyType,
+    val key: String,
+    val account: Account,
+    val createdAt: LocalDateTime
+) {
+
+    fun toGrpcResponse(): ListPixKeysReply.PixKey = ListPixKeysReply.PixKey.newBuilder()
+        .setPixId(uuid.toString())
+        .setKeyType(keyType.toGrpc())
+        .setKey(key)
+        .setAccountType(account.type.toGrpc())
+        .setCreatedAt(with(createdAt.toInstant(ZoneOffset.UTC)) {
+            Timestamp.newBuilder().setNanos(nano).setSeconds(epochSecond).build()
+        })
+        .build()
+}

--- a/src/main/kotlin/br/com/zup/ggwadera/pix/list/ListKeysService.kt
+++ b/src/main/kotlin/br/com/zup/ggwadera/pix/list/ListKeysService.kt
@@ -1,0 +1,19 @@
+package br.com.zup.ggwadera.pix.list
+
+import br.com.zup.ggwadera.pix.PixKeyRepository
+import br.com.zup.ggwadera.util.extensions.toUUID
+import br.com.zup.ggwadera.util.validation.ValidUUID
+import io.micronaut.validation.Validated
+import javax.inject.Singleton
+import javax.validation.constraints.NotBlank
+
+@Singleton
+@Validated
+@Suppress("unused")
+class ListKeysService(
+    private val pixKeyRepository: PixKeyRepository
+) {
+
+    fun findAll(@NotBlank @ValidUUID clientId: String) = pixKeyRepository.findByClientId(clientId.toUUID())
+
+}

--- a/src/main/proto/keymanager.proto
+++ b/src/main/proto/keymanager.proto
@@ -21,6 +21,10 @@ service FindKeyService {
     rpc FindPixKey (FindPixKeyRequest) returns (PixKeyDetailsReply) {};
 }
 
+service ListKeysService {
+    rpc ListPixKeys (ListPixKeysRequest) returns (ListPixKeysReply) {};
+}
+
 enum KeyType {
     KEY_TYPE_UNSPECIFIED = 0;
     CPF = 1;
@@ -89,4 +93,21 @@ message PixKeyDetailsReply {
     KeyOwner owner = 5;
     KeyAccount account = 6;
     google.protobuf.Timestamp created_at = 7;
+}
+
+message ListPixKeysRequest {
+    string client_id = 1;
+}
+
+message ListPixKeysReply {
+    message PixKey {
+        string pix_id = 1;
+        KeyType key_type = 2;
+        string key = 3;
+        AccountType account_type = 4;
+        google.protobuf.Timestamp created_at = 5;
+    }
+
+    string client_id = 1;
+    repeated PixKey keys = 2;
 }

--- a/src/test/kotlin/br/com/zup/ggwadera/pix/list/ListKeysEndpointTest.kt
+++ b/src/test/kotlin/br/com/zup/ggwadera/pix/list/ListKeysEndpointTest.kt
@@ -1,0 +1,82 @@
+package br.com.zup.ggwadera.pix.list
+
+import br.com.zup.ggwadera.ListKeysServiceGrpc
+import br.com.zup.ggwadera.ListPixKeysRequest
+import br.com.zup.ggwadera.pix.*
+import io.grpc.ManagedChannel
+import io.grpc.Status
+import io.grpc.StatusRuntimeException
+import io.micronaut.context.annotation.Factory
+import io.micronaut.grpc.annotation.GrpcChannel
+import io.micronaut.grpc.server.GrpcServerChannel
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import org.junit.jupiter.api.Assertions.assertArrayEquals
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import java.time.LocalDateTime
+import java.util.*
+import javax.inject.Singleton
+
+@MicronautTest
+internal class ListKeysEndpointTest(
+    private val pixKeyRepository: PixKeyRepository,
+    private val grpcClient: ListKeysServiceGrpc.ListKeysServiceBlockingStub
+) {
+    @Factory
+    class Client {
+        @Singleton
+        fun blockingStub(@GrpcChannel(GrpcServerChannel.NAME) channel: ManagedChannel): ListKeysServiceGrpc.ListKeysServiceBlockingStub =
+            ListKeysServiceGrpc.newBlockingStub(channel)
+    }
+
+    val clientId = UUID.randomUUID()
+    val keys = pixKeyRepository.saveAll(
+        listOf(
+            newKey("12345678901", KeyType.CPF),
+            newKey(UUID.randomUUID().toString(), KeyType.RANDOM)
+        )
+    )
+
+    private fun newKey(key: String, keyType: KeyType): PixKey = PixKey(
+        key = key,
+        keyType = keyType,
+        clientId = clientId,
+        account = Account(
+            participant = Account.ISPB_ITAU_UNIBANCO,
+            branch = "1234",
+            number = "123456",
+            type = AccountType.CONTA_CORRENTE
+        ),
+        owner = Owner(
+            name = "Bill Gates",
+            taxIdNumber = "12345678901"
+        ),
+        createdAt = LocalDateTime.now()
+    )
+
+    @Test
+    internal fun `deve listar chaves do usuario`() {
+        val reply =
+            grpcClient.listPixKeys(ListPixKeysRequest.newBuilder().setClientId(clientId.toString()).build())
+        assertEquals(2, reply.keysCount)
+        assertArrayEquals(keys.map { it.key }.toTypedArray(), reply.keysList.map { it.key }.toTypedArray())
+    }
+
+    @Test
+    internal fun `deve retornar lista vazia caso nao encontrar nenhuma chave`() {
+        val reply =
+            grpcClient.listPixKeys(ListPixKeysRequest.newBuilder().setClientId(UUID.randomUUID().toString()).build())
+        assertEquals(0, reply.keysCount)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["", "abcdef", "0e3c8209-7094-4329-90af-473017"])
+    internal fun `deve retornar erro se clientId for invalido`(clientId: String) {
+        assertThrows<StatusRuntimeException> {
+            grpcClient.listPixKeys(ListPixKeysRequest.newBuilder().setClientId(clientId).build())
+        }.run { assertEquals(Status.Code.INVALID_ARGUMENT, status.code) }
+    }
+}


### PR DESCRIPTION
## Necessidades

Agora, precisamos consultar todas as suas chaves Pix cadastradas. Para isso, precisamos listar todas as chaves de um determinado cliente.

## Restrições

Para listar todas as chaves Pix cadastradas, precisamos que o usuário informe os seguintes dados:

- **Identificador do cliente** deve ser obrigatório:
   - Código interno do cliente na Instituição Financeira existente no [Sistema ERP do Itaú](http://localhost:9091/api/v1/private/contas/todas);

## Resultado Esperado

- Em caso de sucesso, deve-se todas as chaves Pix com os seguintes dados:
  - Pix ID;
  - Identificador do cliente;
  - Tipo da chave;
  - Valor da chave;
  - tipo da conta (Corrente ou Poupança);
  - Data/hora de registro ou criação da chave;

- Se nenhuma chave for encontrada deve-se retornar uma coleção vazia;

- Em caso de erro, deve-se retornar o erro específico e amigável para o usuário final;
